### PR TITLE
Introduced special handling of zero dates as null dates.

### DIFF
--- a/FixedWidthParserWriter.Tests/DataLineTest.cs
+++ b/FixedWidthParserWriter.Tests/DataLineTest.cs
@@ -90,6 +90,7 @@ namespace FixedWidthParserWriter.Tests
                     Double = (double)1000.1,
                     Single = (Single)1000.1
                 },
+                new NullableModel(),
                 new NullableModel()
             };
 
@@ -136,6 +137,7 @@ namespace FixedWidthParserWriter.Tests
             var dataLines = new List<string>
             {
                 "char     1000      1000                1000.10             1000.10   1000.10   2019-01-011",
+                "                                                                               0000-00-00 ",
                 "                                                                                          ",
             };
 

--- a/FixedWidthParserWriter/FixedWidthBaseProvider.cs
+++ b/FixedWidthParserWriter/FixedWidthBaseProvider.cs
@@ -338,6 +338,12 @@ namespace FixedWidthParserWriter
 
         private object ParserDateTime(string valueString, string typeName, string format)
         {
+            // Special handling for zero dates, eg. "00000000" for "yyyyMMdd" or "00-00-0000" for "dd-MM-yyyy",
+            // in this case we consider the date as null
+            string zeroDate = String.Concat(format.Select(x => (x >= 'a' && x <= 'z') || (x >= 'A' && x <= 'Z') ? '0' : x));
+            if (valueString == zeroDate)
+                return null;
+
             object value = DateTime.ParseExact(valueString, format, CultureInfo.InvariantCulture);
 
             return value;


### PR DESCRIPTION
First of all, thanks for publishing this useful library. I'm using it in a project and it really saved me a lot of time.

A corner case I've met recently is of dates specified with a padding of '0' to specify a null date. Eg.: `00000000` for null date with format `yyyyMMdd`. In this case the library throws an exception, since DateTime can't parse a zero date in whatever format.

I've added a small fix in the ParseDateTime method to capture this case and return a null date as expected. Feel free to discard, merge or improve on my code.

Keep up the great job!